### PR TITLE
Layer Locking Changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-specter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sketch-specter",
   "description": "A Sketch plugin for easily spec’ing design system elements.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/linkedinlabs/specter-sketch.git"

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -662,6 +662,7 @@ const drawContainerGroup = (groupSettings) => {
     height,
     parent,
     keystone,
+    lock,
   } = groupSettings;
 
   const containerGroup = new Group({
@@ -671,7 +672,7 @@ const drawContainerGroup = (groupSettings) => {
       width,
       height,
     },
-    locked: true,
+    locked: lock,
     name,
     parent,
   });
@@ -718,6 +719,7 @@ const createInnerGroup = (
     width: outerGroupLayer.frame.width,
     height: outerGroupLayer.frame.height,
     keystone: true,
+    lock: false,
   });
 
   // update the `containerSet` object
@@ -756,6 +758,7 @@ const createOuterGroup = (
     width: artboard.frame().width(),
     height: artboard.frame().height(),
     keystone: false,
+    lock: true,
   });
 
   // new object with IDs to add to settings

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -662,7 +662,7 @@ const drawContainerGroup = (groupSettings) => {
     height,
     parent,
     keystone,
-    lock,
+    locked,
   } = groupSettings;
 
   const containerGroup = new Group({
@@ -672,7 +672,7 @@ const drawContainerGroup = (groupSettings) => {
       width,
       height,
     },
-    locked: lock,
+    locked,
     name,
     parent,
   });
@@ -719,7 +719,7 @@ const createInnerGroup = (
     width: outerGroupLayer.frame.width,
     height: outerGroupLayer.frame.height,
     keystone: true,
-    lock: false,
+    locked: false,
   });
 
   // update the `containerSet` object
@@ -758,7 +758,7 @@ const createOuterGroup = (
     width: artboard.frame().width(),
     height: artboard.frame().height(),
     keystone: false,
-    lock: true,
+    locked: true,
   });
 
   // new object with IDs to add to settings

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Annotate and spec design system elements",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/specter-sketch",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "appcast": "https://raw.githubusercontent.com/linkedinlabs/specter-sketch/master/.appcast.xml",
   "compatibleVersion": "55.0",


### PR DESCRIPTION
Change how the Specter layers are locked:

* No longer lock each individual annotation layer or type container layers (i.e. _Components_)
* No longer re-lock layers once they are locked
* Only lock the top-level container layer