### PR TITLE
Separate Dimensions from Spacing

### DIFF
--- a/src/GUI.js
+++ b/src/GUI.js
@@ -109,6 +109,7 @@ const watchGui = () => {
   return browserWindow.loadURL(theWebview);
 };
 export default watchGui;
+
 /**
  * @description Closes the webview when the plugin is shutdown by Sketch
  * (for example, when the user disables the plugin)

--- a/src/Housekeeper.js
+++ b/src/Housekeeper.js
@@ -280,7 +280,8 @@ export default class Housekeeper {
           switch (groupType) {
             case 'component':
             case 'custom':
-            case 'measure':
+            case 'dimension':
+            case 'spacing':
             case 'style':
               updateColor(layer, COLORS[groupType]);
               break;

--- a/src/Housekeeper.js
+++ b/src/Housekeeper.js
@@ -12,8 +12,8 @@ import { COLORS, PLUGIN_IDENTIFIER } from './constants';
  * @type {Array}
  */
 const migrationKeys = [
-  1565814709913,
-  1565809536066,
+  1566025200010,
+  1566025200000,
   1563951600000,
   1561504830674,
   1561503084281,
@@ -271,11 +271,11 @@ export default class Housekeeper {
    * [More info]{@link https://github.com/linkedinlabs/specter-sketch/pull/44}
    *
    * @kind function
-   * @name migration1565814709913
+   * @name migration1566025200010
    *
    * @returns {Object} A result object containing success/error status and log/toast messages.
    */
-  migration1565814709913() {
+  migration1566025200010() {
     const result = {
       status: null,
       messages: {
@@ -283,7 +283,7 @@ export default class Housekeeper {
         log: null,
       },
     };
-    const migrationKey = 1565814709913;
+    const migrationKey = 1566025200010;
     const migrationName = 'separate dimensions from spacing';
     const documentSettings = Settings.documentSettingForKey(this.document, PLUGIN_IDENTIFIER);
 
@@ -420,11 +420,11 @@ export default class Housekeeper {
    * [More info]{@link https://github.com/linkedinlabs/specter-sketch/pull/44}
    *
    * @kind function
-   * @name migration1565809536066
+   * @name migration1566025200000
    *
    * @returns {Object} A result object containing success/error status and log/toast messages.
    */
-  migration1565809536066() {
+  migration1566025200000() {
     const result = {
       status: null,
       messages: {
@@ -432,7 +432,7 @@ export default class Housekeeper {
         log: null,
       },
     };
-    const migrationKey = 1565809536066;
+    const migrationKey = 1566025200000;
     const migrationName = 'separate measurement types';
     const documentSettings = Settings.documentSettingForKey(this.document, PLUGIN_IDENTIFIER);
 

--- a/src/Housekeeper.js
+++ b/src/Housekeeper.js
@@ -12,7 +12,7 @@ import { COLORS, PLUGIN_IDENTIFIER } from './constants';
  * @type {Array}
  */
 const migrationKeys = [
-  1565814709912,
+  1565814709913,
   1565809536066,
   1563951600000,
   1561504830674,
@@ -271,11 +271,11 @@ export default class Housekeeper {
    * [More info]{@link https://github.com/linkedinlabs/specter-sketch/pull/44}
    *
    * @kind function
-   * @name migration1565814709912
+   * @name migration1565814709913
    *
    * @returns {Object} A result object containing success/error status and log/toast messages.
    */
-  migration1565814709912() {
+  migration1565814709913() {
     const result = {
       status: null,
       messages: {
@@ -283,7 +283,7 @@ export default class Housekeeper {
         log: null,
       },
     };
-    const migrationKey = 1565814709912;
+    const migrationKey = 1565814709913;
     const migrationName = 'separate dimensions from spacing';
     const documentSettings = Settings.documentSettingForKey(this.document, PLUGIN_IDENTIFIER);
 
@@ -376,7 +376,10 @@ export default class Housekeeper {
             if (updatedSpacingContainer.layers.length < 1) {
               // if one layer is present, check to see if it’s the keystone layer
               if (updatedSpacingContainer.layers[0].name.includes('keystone')) {
+                // set the flag
                 removeLayer = true;
+                // remove the keystone layer (otherwise it gets kicked into the group above)
+                updatedSpacingContainer.layers[0].remove();
               }
             } else {
               removeLayer = true;

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -935,7 +935,7 @@ const setContainerGroups = (artboard, document, elementType) => {
  *
  * @property layer The layer in the Sketch file that we want to annotate or modify.
  */
-export default class Painter {
+class Painter {
   constructor({ for: layer, in: document }) {
     this.layer = layer;
     this.document = document;
@@ -1414,3 +1414,8 @@ export default class Painter {
     return result;
   }
 }
+
+export {
+  createInnerGroup,
+  Painter,
+};

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -566,8 +566,11 @@ const setGroupName = (elementType) => {
     case 'custom':
       groupName = 'Component Annotations';
       break;
-    case 'measurement':
-      groupName = 'Measurement Annotations';
+    case 'dimension':
+      groupName = 'Dimension Annotations';
+      break;
+    case 'spacing':
+      groupName = 'Spacing Annotations';
       break;
     case 'style':
       groupName = 'Foundation Annotations';
@@ -588,7 +591,10 @@ const setGroupKey = (elementType) => {
     case 'custom':
       groupKey = 'componentInnerGroupId';
       break;
-    case 'measurement':
+    case 'dimension':
+      groupKey = 'dimensionInnerGroupId';
+      break;
+    case 'spacing':
       groupKey = 'measurementInnerGroupId';
       break;
     case 'style':
@@ -631,13 +637,15 @@ const orderContainerLayers = (outerGroupId, document) => {
   const documentSettings = Settings.documentSettingForKey(document, PLUGIN_IDENTIFIER);
   let boundingGroupId = null;
   let componentGroupId = null;
-  let measurementGroupId = null;
+  let dimensionGroupId = null;
+  let spacingGroupId = null;
 
   // find the correct group set and inner groups based on the `outerGroupId`
   documentSettings.containerGroups.forEach((groupSet) => {
     if (groupSet.id === outerGroupId) {
       componentGroupId = groupSet.componentInnerGroupId;
-      measurementGroupId = groupSet.measurementInnerGroupId;
+      dimensionGroupId = groupSet.dimensionInnerGroupId;
+      spacingGroupId = groupSet.measurementInnerGroupId;
       boundingGroupId = groupSet.boundingInnerGroupId;
     }
     return null;
@@ -649,10 +657,18 @@ const orderContainerLayers = (outerGroupId, document) => {
     fromNative(componentGroup).moveToFront();
   }
 
-  // always move measurement annotations group to second from bottom of list
-  const measurementBoxGroup = document.getLayerWithID(measurementGroupId);
-  if (measurementBoxGroup) {
-    fromNative(measurementBoxGroup).moveToBack();
+  // foundations group remains second from top without moving
+
+  // always move spacing annotations group to third from bottom of list
+  const spacingBoxGroup = document.getLayerWithID(spacingGroupId);
+  if (spacingBoxGroup) {
+    fromNative(spacingBoxGroup).moveToBack();
+  }
+
+  // always move dimension annotations group to second from bottom of list
+  const dimensionBoxGroup = document.getLayerWithID(dimensionGroupId);
+  if (dimensionBoxGroup) {
+    fromNative(dimensionBoxGroup).moveToBack();
   }
 
   // always move bounding box group to bottom of list
@@ -1109,7 +1125,7 @@ export default class Painter {
   }
 
   /**
-   * @description Takes a layer and creates two measurement annotations with the layer’s
+   * @description Takes a layer and creates two dimension annotations with the layer’s
    * `height` and `width`.
    *
    * @kind function

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -182,8 +182,11 @@ const buildAnnotation = (
     case 'custom':
       colorHex = COLORS.custom;
       break;
-    case 'measurement':
-      colorHex = COLORS.measure;
+    case 'dimension':
+      colorHex = COLORS.dimension;
+      break;
+    case 'spacing':
+      colorHex = COLORS.spacing;
       break;
     case 'style':
       colorHex = COLORS.style;
@@ -203,13 +206,21 @@ const buildAnnotation = (
     fontFamily = 'system';
   }
 
+  let isMeasurement = false;
+  if (
+    annotationType === 'spacing'
+    || annotationType === 'dimension'
+  ) {
+    isMeasurement = true;
+  }
+
   // build the text box
   const textFrame = {
     x: 16,
     y: 3,
   };
 
-  if (annotationType === 'measurement') {
+  if (isMeasurement) {
     textFrame.x = 4;
     textFrame.y = -1;
   }
@@ -248,7 +259,7 @@ const buildAnnotation = (
   text.adjustToFit();
 
   // build the rounded rectangle
-  const rectHeight = (annotationType === 'measurement' ? 22 : 30) + rectTextBuffer;
+  const rectHeight = (isMeasurement ? 22 : 30) + rectTextBuffer;
   const rectangle = new ShapePath({
     frame: new Rectangle(0, -rectTextBuffer, 200, rectHeight),
     parent: artboard,
@@ -269,7 +280,7 @@ const buildAnnotation = (
   });
 
   // build the dangling diamond
-  const diamondOffset = (annotationType === 'measurement' ? 19 : 27);
+  const diamondOffset = (isMeasurement ? 19 : 27);
   const diamond = new ShapePath({
     frame: new Rectangle(0, diamondOffset, 6, 6),
     name: 'Diamond',
@@ -288,7 +299,7 @@ const buildAnnotation = (
 
   // set rectangle width based on text width
   const textWidth = text.frame.width;
-  const textPadding = (annotationType === 'measurement' ? 6 : 32);
+  const textPadding = (isMeasurement ? 6 : 32);
   const rectangleWidth = textWidth + textPadding;
   rectangle.frame.width = rectangleWidth;
 
@@ -302,7 +313,7 @@ const buildAnnotation = (
   diamond.index = rectangle.index - 1;
 
   let icon = null;
-  if (annotationType === 'measurement') {
+  if (isMeasurement) {
     icon = buildMeasureIcon(artboard, colorHex);
     icon.moveToBack();
     icon.frame.x = diamondMidX - 2;
@@ -389,6 +400,14 @@ const positionAnnotation = (
   const layerX = layerFrame.x;
   const layerY = layerFrame.y;
 
+  let isMeasurement = false;
+  if (
+    annotationType === 'spacing'
+    || annotationType === 'dimension'
+  ) {
+    isMeasurement = true;
+  }
+
   // create the annotation group
   const group = new Group({
     name: groupName,
@@ -431,15 +450,15 @@ const positionAnnotation = (
   // adjustments based on orientation
   switch (orientation) {
     case 'left':
-      offsetX = (annotationType === 'measurement' ? 40 : 38);
+      offsetX = (isMeasurement ? 40 : 38);
       placementX = layerX - offsetX;
       break;
     case 'right':
-      offsetX = (annotationType === 'measurement' ? 12 : 5);
+      offsetX = (isMeasurement ? 12 : 5);
       placementX = layerX + layerWidth + offsetX;
       break;
     default: // top
-      offsetY = (annotationType === 'measurement' ? 33 : 38);
+      offsetY = (isMeasurement ? 33 : 38);
       placementY = layerY - offsetY;
   }
 
@@ -515,7 +534,7 @@ const positionAnnotation = (
     icon.remove();
 
     // redraw icon in vertical orientation
-    const iconNew = buildMeasureIcon(group, COLORS.measure, 'vertical');
+    const iconNew = buildMeasureIcon(group, COLORS.dimension, 'vertical');
 
     // resize icon based on gap/layer height
     iconNew.frame.height = layerHeight;
@@ -1117,7 +1136,7 @@ export default class Painter {
     }
 
     // set up some information
-    const annotationType = 'measurement';
+    const annotationType = 'dimension';
     const layerId = fromNative(this.layer).id;
     const layerName = this.layer.name();
 
@@ -1288,7 +1307,7 @@ export default class Painter {
 
     // set up some information
     const annotationText = gapFrame.orientation === 'vertical' ? setSpacingText(gapFrame.width) : setSpacingText(gapFrame.height);
-    const annotationType = 'measurement';
+    const annotationType = 'spacing';
     const layerName = this.layer.name();
     const groupName = `Spacing for ${layerName}`;
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -596,7 +596,7 @@ const setGroupKey = (elementType) => {
       groupKey = 'dimensionInnerGroupId';
       break;
     case 'spacing':
-      groupKey = 'measurementInnerGroupId';
+      groupKey = 'spacingInnerGroupId';
       break;
     case 'style':
       groupKey = 'styleInnerGroupId';
@@ -646,7 +646,7 @@ const orderContainerLayers = (outerGroupId, document) => {
     if (groupSet.id === outerGroupId) {
       componentGroupId = groupSet.componentInnerGroupId;
       dimensionGroupId = groupSet.dimensionInnerGroupId;
-      spacingGroupId = groupSet.measurementInnerGroupId;
+      spacingGroupId = groupSet.spacingInnerGroupId;
       boundingGroupId = groupSet.boundingInnerGroupId;
     }
     return null;

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -740,7 +740,7 @@ const drawContainerGroup = (groupSettings) => {
  * updated parent container group settings object.
  * @private
  */
-const createInnerGroup = (
+export const createInnerGroup = (
   outerGroupLayer,
   containerSet,
   elementType,
@@ -935,7 +935,7 @@ const setContainerGroups = (artboard, document, elementType) => {
  *
  * @property layer The layer in the Sketch file that we want to annotate or modify.
  */
-class Painter {
+export default class Painter {
   constructor({ for: layer, in: document }) {
     this.layer = layer;
     this.document = document;
@@ -1414,8 +1414,3 @@ class Painter {
     return result;
   }
 }
-
-export {
-  createInnerGroup,
-  Painter,
-};

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -1200,7 +1200,7 @@ export default class Painter {
     // ------------------------
     // construct the height annotation elements
     const annotationTextHeight = `${this.layer.frame().height()}dp`;
-    const groupNameHeight = `Dimension Width for layer ${layerName}`;
+    const groupNameHeight = `Dimension Height for layer ${layerName}`;
     const annotationHeight = buildAnnotation(
       annotationTextHeight,
       null, // annotationSecondaryText

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -534,7 +534,8 @@ const positionAnnotation = (
     icon.remove();
 
     // redraw icon in vertical orientation
-    const iconNew = buildMeasureIcon(group, COLORS.dimension, 'vertical');
+    const measureIconColor = (annotationType === 'spacing' ? COLORS.spacing : COLORS.dimension);
+    const iconNew = buildMeasureIcon(group, measureIconColor, 'vertical');
 
     // resize icon based on gap/layer height
     iconNew.frame.height = layerHeight;

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,7 +25,8 @@ const PLUGIN_NAME = 'Specter';
 const COLORS = {
   component: '#9966ff',
   custom: '#ff3399',
-  measure: '#00cc99',
+  dimension: '#99cc00',
+  spacing: '#00cc99',
   style: '#ff6655',
 };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Specter",
   "description": "Annotate and spec design system elements",
-  "author": "LinkedIn Labs",
+  "author": "LinkedIn",
   "homepage": "https://github.com/linkedinlabs/specter-sketch",
   "version": "1.0.3",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",


### PR DESCRIPTION
Gives Dimension Annotations their own color and layer grouping.

<img width="516" alt="Screen Shot 2019-08-13 at 1 34 40 PM" src="https://user-images.githubusercontent.com/867428/62975404-2188bc80-bdcf-11e9-94b8-8d133dde96e6.png">

- [x] Migration to move `measurementInnerGroupId` to `spacingInnerGroupId`
- [x] Migration to adjust color and re-group Dimension Annotations?
- [x] Bump Migration tag(s) before release