### PR TITLE
Spacing: Annotate overlapped layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-specter",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sketch-specter",
   "description": "A Sketch plugin for easily spec’ing design system elements.",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/linkedinlabs/specter-sketch.git"

--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -272,4 +272,99 @@ export default class Crawler {
 
     return theFrame;
   }
+
+  /** WIP
+   * @description Simulates Sketch’s frame() object, but for the space between two
+   * selected layers. It keeps the coordinates relative to the artboard, ignoring
+   * if some of the items are grouped inside other layers. It also adds an orientation
+   * `horizontal` or `vertical` based on the gap orientation. Assumes only 2 layers
+   * are selected.
+   *
+   * @kind function
+   * @name overlapFrames
+   * @returns {Object} The `x`, `y` coordinates, `width`, `height`, and `orientation`
+   * of an entire selection. It also includes layer IDs (`layerAId` and `layerBId`)
+   * for the two layers used to calculated the gap frame.
+   */
+  overlapFrames() {
+    const theFrames = {
+      top: {
+        x: null,
+        y: null,
+        width: 0,
+        height: 0,
+        orientation: 'vertical',
+      },
+      bottom: {
+        x: null,
+        y: null,
+        width: 0,
+        height: 0,
+        orientation: 'vertical',
+      },
+      right: {
+        x: null,
+        y: null,
+        width: 0,
+        height: 0,
+        orientation: 'vertical',
+      },
+      left: {
+        x: null,
+        y: null,
+        width: 0,
+        height: 0,
+        orientation: 'vertical',
+      },
+      layerAId: null,
+      layerBId: null,
+    };
+
+    // use `gapFrame` to first ensure that the itemse do actually overlap
+    const gapFrame = this.gapFrame();
+
+    if (gapFrame) {
+      return null;
+    }
+
+    // set the selection
+    const selection = setArray(this.array);
+
+    // set shorthand for `getPositionOnArtboard`
+    const aPos = getPositionOnArtboard;
+
+    // set the layers to a default for comparisons
+    let layerA = selection[0];
+    let layerB = selection[0];
+
+    // find biggest (`layerA`) and smallest (`layerB`) layers
+    let layerAArea = (layerA.frame().width() * layerA.frame().height());
+    let layerBArea = (layerB.frame().width() * layerB.frame().height());
+
+    // set the largest layer to `layerA` and the smallest to `layerB`
+    // if `layerB` is currently the largest, we have to flip them
+    selection.forEach((layer) => {
+      const layerArea = (layer.frame().width() * layer.frame().height());
+      if (layerArea > layerAArea) {
+        layerA = layer;
+        layerAArea = layerArea;
+      }
+
+      if (layerArea < layerAArea) {
+        layerB = layer;
+        layerBArea = layerArea;
+      }
+    });
+
+    // we need a dominant layer to orient positioning;
+    // if both layers are exactly the same size, we cannot assume dominance
+    if (layerAArea === layerBArea) {
+      return null;
+    }
+
+    // set frames
+
+    // deliver the result
+    return theFrames;
+  }
 }

--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -273,8 +273,8 @@ export default class Crawler {
     return theFrame;
   }
 
-  /** WIP
-   * @description Simulates Sketch’s frame() object, but for the space between two
+  /**
+   * @description Creates four separate frames for the spaces around two overlapping
    * selected layers. It keeps the coordinates relative to the artboard, ignoring
    * if some of the items are grouped inside other layers. It also adds an orientation
    * `horizontal` or `vertical` based on the gap orientation. Assumes only 2 layers
@@ -282,9 +282,10 @@ export default class Crawler {
    *
    * @kind function
    * @name overlapFrames
-   * @returns {Object} The `x`, `y` coordinates, `width`, `height`, and `orientation`
-   * of an entire selection. It also includes layer IDs (`layerAId` and `layerBId`)
-   * for the two layers used to calculated the gap frame.
+   * @returns {Object} The `top`, `bottom`, `right`, and `left` frames. Each frame
+   * contains `x`, `y` coordinates, `width`, `height`, and `orientation`.
+   * The object also includes layer IDs (`layerAId` and `layerBId`)
+   * for the two layers used to calculated the overlapped areas.
    */
   overlapFrames() {
     /**
@@ -313,9 +314,10 @@ export default class Crawler {
       return layerIndex;
     };
 
-    // use `gapFrame` to first ensure that the itemse do actually overlap
+    // use `gapFrame` to first ensure that the items do actually overlap
     const gapFrame = this.gapFrame();
 
+    // if items do not overlap, cannot create an `overlapFrame`
     if (gapFrame) {
       return null;
     }

--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -335,7 +335,7 @@ export default class Crawler {
     const topWidth = layerB.frame().width();
     const topHeight = aPos(layerB).y - aPos(layerA).y;
     const topX = aPos(layerB).x;
-    const topY = layerA.frame().y();
+    const topY = aPos(layerA).y;
     // bottom
     const bottomWidth = layerB.frame().width();
     const bottomHeight = layerA.frame().height() - topHeight - layerB.frame().height();

--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -287,39 +287,6 @@ export default class Crawler {
    * for the two layers used to calculated the gap frame.
    */
   overlapFrames() {
-    const theFrames = {
-      top: {
-        x: null,
-        y: null,
-        width: 0,
-        height: 0,
-        orientation: 'vertical',
-      },
-      bottom: {
-        x: null,
-        y: null,
-        width: 0,
-        height: 0,
-        orientation: 'vertical',
-      },
-      right: {
-        x: null,
-        y: null,
-        width: 0,
-        height: 0,
-        orientation: 'vertical',
-      },
-      left: {
-        x: null,
-        y: null,
-        width: 0,
-        height: 0,
-        orientation: 'vertical',
-      },
-      layerAId: null,
-      layerBId: null,
-    };
-
     // use `gapFrame` to first ensure that the itemse do actually overlap
     const gapFrame = this.gapFrame();
 
@@ -362,7 +329,62 @@ export default class Crawler {
       return null;
     }
 
-    // set frames
+    // -------- set frames - essentially defining rectangles in the overapped spaces
+    // between the too layers
+    // top
+    const topWidth = layerB.frame().width();
+    const topHeight = aPos(layerB).y - aPos(layerA).y;
+    const topX = aPos(layerB).x;
+    const topY = layerA.frame().y();
+    // bottom
+    const bottomWidth = layerB.frame().width();
+    const bottomHeight = layerA.frame().height() - topHeight - layerB.frame().height();
+    const bottomX = aPos(layerB).x;
+    const bottomY = aPos(layerA).y + topHeight + layerB.frame().height();
+    // left
+    const leftWidth = aPos(layerB).x - aPos(layerA).x;
+    const leftHeight = layerB.frame().height();
+    const leftX = aPos(layerA).x;
+    const leftY = aPos(layerB).y;
+    // right
+    const rightWidth = layerA.frame().width() - layerB.frame().width() - leftWidth;
+    const rightHeight = layerB.frame().height();
+    const rightX = aPos(layerB).x + layerB.frame().width();
+    const rightY = aPos(layerB).y;
+
+    // set the frames
+    const theFrames = {
+      top: {
+        x: topX,
+        y: topY,
+        width: topWidth,
+        height: topHeight,
+        orientation: 'horizontal',
+      },
+      bottom: {
+        x: bottomX,
+        y: bottomY,
+        width: bottomWidth,
+        height: bottomHeight,
+        orientation: 'horizontal',
+      },
+      right: {
+        x: rightX,
+        y: rightY,
+        width: rightWidth,
+        height: rightHeight,
+        orientation: 'vertical',
+      },
+      left: {
+        x: leftX,
+        y: leftY,
+        width: leftWidth,
+        height: leftHeight,
+        orientation: 'vertical',
+      },
+      layerAId: fromNative(layerA).id,
+      layerBId: fromNative(layerB).id,
+    };
 
     // deliver the result
     return theFrames;

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -119,12 +119,7 @@ const watchGui = () => {
   webContents.on('drawBoundingBox', () => drawBoundingBox());
 
   // close the webview window
-  webContents.on('closeWindow', () => {
-    if (existingWebview) {
-      existingWebview.close();
-      messenger.log('GUI closed.');
-    }
-  });
+  webContents.on('closeWindow', () => onShutdown());
 
   // load the webview window
   return browserWindow.loadURL(theWebview);

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -30,6 +30,21 @@ const webviewIdentifier = `${PLUGIN_IDENTIFIER}.webview`;
 const messenger = new Messenger({ for: { action: 'GUI' } });
 
 /**
+ * @description Closes the webview when the plugin is shutdown by Sketch
+ * (for example, when the user disables the plugin)
+ *
+ * @kind function
+ * @name onShutdown
+ */
+export const onShutdown = () => {
+  const existingWebview = getWebview(webviewIdentifier);
+  if (existingWebview) {
+    existingWebview.close();
+    messenger.log('GUI closed.');
+  }
+};
+
+/**
  * @description Called by the plugin manifest to open and operate the UI.
  *
  * @kind function
@@ -37,6 +52,13 @@ const messenger = new Messenger({ for: { action: 'GUI' } });
  * @returns {Object} An open webview in the Sketch UI.
  */
 const watchGui = () => {
+  // check to see if the webview is already open
+  // if so, close it
+  const existingWebview = getWebview(webviewIdentifier);
+  if (existingWebview) {
+    return onShutdown();
+  }
+
   /**
    * @description Options to set on BrowserWindow.
    *
@@ -98,7 +120,6 @@ const watchGui = () => {
 
   // close the webview window
   webContents.on('closeWindow', () => {
-    const existingWebview = getWebview(webviewIdentifier);
     if (existingWebview) {
       existingWebview.close();
       messenger.log('GUI closed.');
@@ -109,18 +130,3 @@ const watchGui = () => {
   return browserWindow.loadURL(theWebview);
 };
 export default watchGui;
-
-/**
- * @description Closes the webview when the plugin is shutdown by Sketch
- * (for example, when the user disables the plugin)
- *
- * @kind function
- * @name onShutdown
- */
-export const onShutdown = () => {
-  const existingWebview = getWebview(webviewIdentifier);
-  if (existingWebview) {
-    existingWebview.close();
-    messenger.log('GUI closed.');
-  }
-};

--- a/src/Messenger.js
+++ b/src/Messenger.js
@@ -49,7 +49,7 @@ export default class Messenger {
     if (this.document && UI.message !== undefined) {
       UI.message(message, this.document);
     } else {
-      this.sendLog(`Could not display: “${message}”`, 'error');
+      this.log(`Could not display: “${message}”`, 'error');
     }
   }
 
@@ -65,7 +65,7 @@ export default class Messenger {
     if (this.document && UI.message !== undefined) {
       UI.alert(title, message);
     } else {
-      this.sendLog(`Could not display: “${message}”`, 'error');
+      this.log(`Could not display: “${message}”`, 'error');
     }
   }
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -1408,12 +1408,19 @@ export default class Painter {
     return result;
   }
 
-  /** WIP
-   * @description asf
+  /**
+   * @description Takes a `spacingFrame` object and creates a spacing measurement annotation
+   * with the correct spacing number (“IS-X”). If the calculated spacing number is larger
+   * than “IS-9”, the annotation is not created.
    *
    * @kind function
    * @name addSpacingAnnotation
-  */
+   * @param {Object} spacingFrame The `x`, `y` coordinates, `width`, `height`, and `orientation`
+   * of an entire selection. It should also includes layer IDs (`layerAId` and `layerBId`)
+   * for the two layers used to calculated the gap.
+   *
+   * @returns null
+   */
   addSpacingAnnotation(spacingFrame) {
     // set up some information
     const measurementToUse = spacingFrame.orientation === 'vertical' ? spacingFrame.width : spacingFrame.height;
@@ -1569,15 +1576,19 @@ export default class Painter {
     return result;
   }
 
-  /** WIP
-   * @description Takes a `overlapFrames` object from Crawler and creates a spacing measurement
-   * annotation with the correct spacing number (“IS-X”).
+  /**
+   * @description Takes a `overlapFrames` object from Crawler and creates spacing measurement
+   * annotations with the correct spacing number (“IS-X”) in the selected directions (top, bottom,
+   * right, and left). The default is all four directions.
    *
    * @kind function
    * @name addOverlapMeasurements
-   * @param {Object} overlapFrames The `x`, `y` coordinates, `width`, `height`, and `orientation`
-   * of an entire selection. It should also includes layer IDs (`layerAId` and `layerBId`)
-   * for the two layers used to calculated the gap.
+   * @param {Object} overlapFrames The `top`, `bottom`, `right`, and `left` frames. Each frame
+   * contains `x`, `y` coordinates, `width`, `height`, and `orientation`. The object also includes
+   * layer IDs (`layerAId` and `layerBId`) for the two layers used to calculated the
+   * overlapped areas.
+   * @param {array} directions An optional array containing 4 unique strings representating
+   * the annotation directions: `top`, `bottom`, `right`, `left`.
    *
    * @returns {Object} A result object container success/error status and log/toast messages.
    */

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -434,7 +434,7 @@ const positionAnnotation = (
   }
 
   // ------- position the group within the artboard, above the layer receiving the annotation
-  let diamondAdjustment = null;
+  let horizontalAdjustment = null;
 
   // initial placement based on layer to annotate
 
@@ -453,6 +453,7 @@ const positionAnnotation = (
 
   let offsetX = null;
   let offsetY = null;
+  let iconOffsetX = 0;
   let iconOffsetY = 0;
 
   // adjustments based on orientation
@@ -473,13 +474,25 @@ const positionAnnotation = (
   // correct for left bleed
   if (placementX < 0) {
     placementX = 5;
-    diamondAdjustment = 'left';
+    horizontalAdjustment = 'left';
+
+    // dimension/spacing annotations get their own special correction
+    if (icon) {
+      placementX = 2;
+      iconOffsetX = placementX;
+    }
   }
 
   // correct for right bleed
   if ((placementX + group.frame.width) > artboardWidth) {
     placementX = artboardWidth - group.frame.width - 5;
-    diamondAdjustment = 'right';
+    horizontalAdjustment = 'right';
+
+    // dimension/spacing annotations get their own special correction
+    if (icon) {
+      placementX -= 3;
+      iconOffsetX = placementX;
+    }
   }
 
   // correct for top bleed
@@ -501,10 +514,10 @@ const positionAnnotation = (
   group.frame.y = placementY - relativeGroupFrame.y;
 
   // adjust diamond on horizonal placement, if necessary
-  if (diamondAdjustment) {
+  if (horizontalAdjustment) {
     // move the diamond to the mid-point of the layer to annotate
     let diamondLayerMidX = null;
-    switch (diamondAdjustment) {
+    switch (horizontalAdjustment) {
       case 'left':
         diamondLayerMidX = ((layerX - group.frame.x) + ((layerWidth - 6) / 2));
         break;
@@ -541,7 +554,19 @@ const positionAnnotation = (
   // adjust the measure icon width for top-oriented annotations
   if (orientation === 'top' && icon) {
     icon.frame.width = layerWidth;
-    icon.frame.x = (rectangle.frame.width - layerWidth) / 2;
+
+    if (iconOffsetX > 0) {
+      if (horizontalAdjustment === 'left') {
+        icon.frame.x -= getPositionOnArtboard(icon.sketchObject).x;
+      } else {
+        icon.frame.x = (
+          artboardWidth - getPositionOnArtboard(group.sketchObject).x - icon.frame.width
+        );
+      }
+    } else {
+      icon.frame.x = (rectangle.frame.width - layerWidth) / 2;
+    }
+
     icon.adjustToFit();
   }
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -1282,49 +1282,18 @@ export default class Painter {
     return result;
   }
 
-  /**
-   * @description Takes a `gapFrame` object from Crawler and creates a spacing measurement
-   * annotation with the correct spacing number (“IS-X”).
+  /** WIP
+   * @description asf
    *
    * @kind function
-   * @name addGapMeasurement
-   * @param {Object} gapFrame The `x`, `y` coordinates, `width`, `height`, and `orientation`
-   * of an entire selection. It should also includes layer IDs (`layerAId` and `layerBId`)
-   * for the two layers used to calculated the gap.
-   *
-   * @returns {Object} A result object container success/error status and log/toast messages.
-   */
-  addGapMeasurement(gapFrame) {
-    const result = {
-      status: null,
-      messages: {
-        alert: null,
-        toast: null,
-        log: null,
-      },
-    };
-
-    // return an error if the selection is not placed on an artboard
-    if (!this.artboard) {
-      result.status = 'error';
-      result.messages.log = 'Selection not on artboard';
-      result.messages.alert = 'Your selection needs to be on an artboard';
-      return result;
-    }
-
-    // return an error if the selection is not placed on an artboard
-    if (!gapFrame) {
-      result.status = 'error';
-      result.messages.log = 'gapFrame is missing';
-      result.messages.alert = 'Could not find a gap in your selection';
-      return result;
-    }
-
+   * @name addSpacingAnnotation
+  */
+  addSpacingAnnotation(spacingFrame) {
     // set up some information
-    const annotationText = gapFrame.orientation === 'vertical' ? setSpacingText(gapFrame.width) : setSpacingText(gapFrame.height);
+    const annotationText = spacingFrame.orientation === 'vertical' ? setSpacingText(spacingFrame.width) : setSpacingText(spacingFrame.height);
     const annotationType = 'spacing';
     const layerName = this.layer.name();
-    const groupName = `Spacing for ${layerName}`;
+    const groupName = `Spacing for ${layerName} (${spacingFrame.type})`;
 
     // create or locate the container group
     const { containerGroup, innerContainerGroup } = setContainerGroups(
@@ -1341,7 +1310,11 @@ export default class Painter {
     if (documentSettings && documentSettings.annotatedSpacings) {
       // remove the old ID pair(s) from the `newDocumentSettings` array
       documentSettings.annotatedSpacings.forEach((layerSet) => {
-        if (layerSet.layerAId === gapFrame.layerAId && layerSet.layerBId === gapFrame.layerBId) {
+        if (
+          layerSet.layerAId === spacingFrame.layerAId
+          && layerSet.layerBId === spacingFrame.layerBId
+          && layerSet.type === spacingFrame.type
+        ) {
           this.removeAnnotation(layerSet);
 
           // remove the layerSet from the `newDocumentSettings` array
@@ -1366,14 +1339,14 @@ export default class Painter {
     // group and position the base annotation elements
     const layerFrame = {
       artboardWidth: this.artboard.frame().width(),
-      width: gapFrame.width,
-      height: gapFrame.height,
-      x: gapFrame.x,
-      y: gapFrame.y,
+      width: spacingFrame.width,
+      height: spacingFrame.height,
+      x: spacingFrame.x,
+      y: spacingFrame.y,
       index: fromNative(this.layer).index,
     };
 
-    const annotationOrientation = (gapFrame.orientation === 'vertical' ? 'top' : 'left');
+    const annotationOrientation = (spacingFrame.orientation === 'vertical' ? 'top' : 'left');
     const group = positionAnnotation(
       innerContainerGroup,
       groupName,
@@ -1387,8 +1360,9 @@ export default class Painter {
     const newAnnotatedSpacingSet = {
       containerGroupId: fromNative(containerGroup).id,
       id: group.id,
-      layerAId: gapFrame.layerAId,
-      layerBId: gapFrame.layerBId,
+      layerAId: spacingFrame.layerAId,
+      layerBId: spacingFrame.layerBId,
+      direction: spacingFrame.direction,
     };
 
     // update the `newDocumentSettings` array
@@ -1405,6 +1379,119 @@ export default class Painter {
       PLUGIN_IDENTIFIER,
       newDocumentSettings,
     );
+  }
+
+  /**
+   * @description Takes a `spacingFrame` object from Crawler and creates a spacing measurement
+   * annotation with the correct spacing number (“IS-X”).
+   *
+   * @kind function
+   * @name addGapMeasurement
+   * @param {Object} spacingFrame The `x`, `y` coordinates, `width`, `height`, and `orientation`
+   * of an entire selection. It should also includes layer IDs (`layerAId` and `layerBId`)
+   * for the two layers used to calculated the gap.
+   *
+   * @returns {Object} A result object container success/error status and log/toast messages.
+   */
+  addGapMeasurement(spacingFrame) {
+    const result = {
+      status: null,
+      messages: {
+        alert: null,
+        toast: null,
+        log: null,
+      },
+    };
+
+    // return an error if the selection is not placed on an artboard
+    if (!this.artboard) {
+      result.status = 'error';
+      result.messages.log = 'Selection not on artboard';
+      result.messages.alert = 'Your selection needs to be on an artboard';
+      return result;
+    }
+
+    // return an error if the selection is not placed on an artboard
+    if (!spacingFrame) {
+      result.status = 'error';
+      result.messages.log = 'spacingFrame is missing';
+      result.messages.alert = 'Could not find a gap in your selection';
+      return result;
+    }
+
+    // set type
+    spacingFrame.type = 'gap'; // eslint-disable-line no-param-reassign
+
+    // add the annotation
+    this.addSpacingAnnotation(spacingFrame);
+
+    // return a successful result
+    result.status = 'success';
+    result.messages.log = `Spacing annotated for “${this.layer.name()}”`;
+    return result;
+  }
+
+  /** WIP
+   * @description Takes a `overlapFrames` object from Crawler and creates a spacing measurement
+   * annotation with the correct spacing number (“IS-X”).
+   *
+   * @kind function
+   * @name addOverlapMeasurements
+   * @param {Object} overlapFrames The `x`, `y` coordinates, `width`, `height`, and `orientation`
+   * of an entire selection. It should also includes layer IDs (`layerAId` and `layerBId`)
+   * for the two layers used to calculated the gap.
+   *
+   * @returns {Object} A result object container success/error status and log/toast messages.
+   */
+  addOverlapMeasurements(overlapFrames) {
+    const result = {
+      status: null,
+      messages: {
+        alert: null,
+        toast: null,
+        log: null,
+      },
+    };
+
+    // return an error if the selection is not placed on an artboard
+    if (!this.artboard) {
+      result.status = 'error';
+      result.messages.log = 'Selection not on artboard';
+      result.messages.alert = 'Your selection needs to be on an artboard';
+      return result;
+    }
+
+    // return an error if the selection is not placed on an artboard
+    if (!overlapFrames) {
+      result.status = 'error';
+      result.messages.log = 'overlapFrames is missing';
+      result.messages.alert = 'Could not find a overlapped layers in your selection';
+      return result;
+    }
+
+    const types = ['top', 'bottom', 'right', 'left'];
+
+    types.forEach((type) => {
+      let frameX = overlapFrames[type].x + (overlapFrames[type].width / 2);
+      let frameY = overlapFrames[type].y;
+      if ((type === 'left') || (type === 'right')) {
+        frameY = overlapFrames[type].y + (overlapFrames[type].height / 2);
+        frameX = overlapFrames[type].x;
+      }
+
+      const spacingFrame = {
+        x: frameX,
+        y: frameY,
+        width: overlapFrames[type].width,
+        height: overlapFrames[type].height,
+        orientation: overlapFrames[type].orientation,
+        layerAId: overlapFrames.layerAId,
+        layerBId: overlapFrames.layerBId,
+        type,
+      };
+
+      this.addSpacingAnnotation(spacingFrame);
+    });
 
     // return a successful result
     result.status = 'success';

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -568,6 +568,17 @@ const positionAnnotation = (
   return group;
 };
 
+/**
+ * @description Takes a string representing the type of element getting painted and
+ * returns the name of the group used for that element.
+ *
+ * @kind function
+ * @name setGroupName
+ * @param {string} elementType A string representing the type of element getting painted.
+ *
+ * @returns {string} The name of the group getting painted.
+ * @private
+ */
 const setGroupName = (elementType) => {
   let groupName = null;
   switch (elementType) {
@@ -593,6 +604,17 @@ const setGroupName = (elementType) => {
   return groupName;
 };
 
+/**
+ * @description Takes a string representing the type of element getting painted and
+ * returns the key used in document settings to represent data linked to the element.
+ *
+ * @kind function
+ * @name setGroupKey
+ * @param {string} elementType A string representing the type of element getting painted.
+ *
+ * @returns {string} The key representing the type of element getting painted.
+ * @private
+ */
 const setGroupKey = (elementType) => {
   let groupKey = null;
   switch (elementType) {

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -683,20 +683,20 @@ const setGroupKey = (elementType) => {
  * the appropriate spacing annotation text.
  *
  * @kind function
- * @name setSpacingText
+ * @name retrieveSpacingValue
  * @param {number} length A number representing length.
  * @returns {string} A text label based on the spacing value.
  * @private
  */
-const setSpacingText = (length) => {
-  let itemSpacingValue = 1;
+const retrieveSpacingValue = (length) => {
+  let itemSpacingValue = null;
 
   // IS-X spacing is not an even scale
   // set some breakpoints and “round” `length` to the nearest proper IS-X number
+  // ignore anything so large that it’s above `IS-9`
   switch (true) {
-    case (length >= 128): // 160 – IS-10 (not actually specc'd in Art Deco)
-      itemSpacingValue = 10;
-      break;
+    case (length >= 128): // based on 160 – IS-10 (not actually specc'd in Art Deco)
+      return itemSpacingValue;
     case (length >= 80): // 96 – IS-9
       itemSpacingValue = 9;
       break;
@@ -719,8 +719,7 @@ const setSpacingText = (length) => {
       itemSpacingValue = Math.round(length / 4);
   }
 
-  const text = `IS-${itemSpacingValue}`;
-  return text;
+  return itemSpacingValue;
 };
 
 /**
@@ -1379,7 +1378,16 @@ export default class Painter {
   */
   addSpacingAnnotation(spacingFrame) {
     // set up some information
-    const annotationText = spacingFrame.orientation === 'vertical' ? setSpacingText(spacingFrame.width) : setSpacingText(spacingFrame.height);
+    const measurementToUse = spacingFrame.orientation === 'vertical' ? spacingFrame.width : spacingFrame.height;
+    const spacingValue = retrieveSpacingValue(measurementToUse);
+
+    // if there is no `spacingValue`, the measurement is above an `IS-9` and
+    // isn’t considered valid
+    if (!spacingValue) {
+      return null;
+    }
+
+    const annotationText = `IS-${spacingValue}`;
     const annotationType = 'spacing';
     const layerName = this.layer.name();
     const groupName = `Spacing for ${layerName} (${spacingFrame.type})`;
@@ -1468,6 +1476,8 @@ export default class Painter {
       PLUGIN_IDENTIFIER,
       newDocumentSettings,
     );
+
+    return null;
   }
 
   /**

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -453,6 +453,7 @@ const positionAnnotation = (
 
   let offsetX = null;
   let offsetY = null;
+  let iconOffsetY = 0;
 
   // adjustments based on orientation
   switch (orientation) {
@@ -484,6 +485,12 @@ const positionAnnotation = (
   // correct for top bleed
   if (placementY < 0) {
     placementY = 5;
+
+    // dimension/spacing annotations get their own special correction
+    if (icon) {
+      placementY = 2;
+      iconOffsetY = placementY;
+    }
   }
 
   // find container frame, relative to artboard
@@ -550,12 +557,18 @@ const positionAnnotation = (
     // resize icon based on gap/layer height
     iconNew.frame.height = layerHeight;
 
-    // position icon based on orientation
-    if (orientation === 'right') {
-      iconNew.frame.y = (rectangle.frame.height - layerHeight) / 2;
-      iconNew.frame.x = rectangle.frame.x - 10;
+    // position icon on `y`
+    if (iconOffsetY > 0) {
+      // move the icon back to the top of the artboard
+      iconNew.frame.y -= getPositionOnArtboard(iconNew.sketchObject).y;
     } else {
       iconNew.frame.y = (rectangle.frame.height - layerHeight) / 2;
+    }
+
+    // position icon on `x` based on orientation
+    if (orientation === 'right') {
+      iconNew.frame.x = rectangle.frame.x - 10;
+    } else {
       iconNew.frame.x = rectangle.frame.x + rectangle.frame.width + 4;
     }
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -1428,7 +1428,7 @@ export default class Painter {
     const annotationText = `IS-${spacingValue}`;
     const annotationType = 'spacing';
     const layerName = this.layer.name();
-    const groupName = `Spacing for ${layerName} (${spacingFrame.type})`;
+    const groupName = `Spacing for ${layerName} (${spacingFrame.direction})`;
 
     // create or locate the container group
     const { containerGroup, innerContainerGroup } = setContainerGroups(
@@ -1448,7 +1448,7 @@ export default class Painter {
         if (
           layerSet.layerAId === spacingFrame.layerAId
           && layerSet.layerBId === spacingFrame.layerBId
-          && layerSet.type === spacingFrame.type
+          && layerSet.direction === spacingFrame.direction
         ) {
           this.removeAnnotation(layerSet);
 
@@ -1557,8 +1557,8 @@ export default class Painter {
       return result;
     }
 
-    // set type
-    spacingFrame.type = 'gap'; // eslint-disable-line no-param-reassign
+    // set direction (type)
+    spacingFrame.direction = 'gap'; // eslint-disable-line no-param-reassign
 
     // add the annotation
     this.addSpacingAnnotation(spacingFrame);
@@ -1607,33 +1607,33 @@ export default class Painter {
       return result;
     }
 
-    const types = ['top', 'bottom', 'right', 'left'];
+    const directions = ['top', 'bottom', 'right', 'left'];
 
-    types.forEach((type) => {
+    directions.forEach((direction) => {
       // do not annotate if the results are negative, or less than a single
       // IS-X spacing unit
-      if (overlapFrames[type].width <= 2 || overlapFrames[type].height <= 2) {
+      if (overlapFrames[direction].width <= 2 || overlapFrames[direction].height <= 2) {
         return null;
       }
 
       // otherwise, set up the frame we can use for the annotation
-      let frameX = overlapFrames[type].x + (overlapFrames[type].width / 2);
-      let frameY = overlapFrames[type].y;
+      let frameX = overlapFrames[direction].x + (overlapFrames[direction].width / 2);
+      let frameY = overlapFrames[direction].y;
 
-      if ((type === 'left') || (type === 'right')) {
-        frameY = overlapFrames[type].y + (overlapFrames[type].height / 2);
-        frameX = overlapFrames[type].x;
+      if ((direction === 'left') || (direction === 'right')) {
+        frameY = overlapFrames[direction].y + (overlapFrames[direction].height / 2);
+        frameX = overlapFrames[direction].x;
       }
 
       const spacingFrame = {
         x: frameX,
         y: frameY,
-        width: overlapFrames[type].width,
-        height: overlapFrames[type].height,
-        orientation: overlapFrames[type].orientation,
+        width: overlapFrames[direction].width,
+        height: overlapFrames[direction].height,
+        orientation: overlapFrames[direction].orientation,
         layerAId: overlapFrames.layerAId,
         layerBId: overlapFrames.layerBId,
-        type,
+        direction,
       };
 
       return this.addSpacingAnnotation(spacingFrame);

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -350,7 +350,7 @@ const buildBoundingBox = (frame, containerGroup) => {
   const placementX = frame.x - relativeGroupFrame.x;
   const placementY = frame.y - relativeGroupFrame.y;
 
-  // build the rounded rectangle
+  // build the semi-transparent rectangle
   const boundingBox = new ShapePath({
     frame: new Rectangle(placementX, placementY, frame.width, frame.height),
     name: 'Bounding Box',

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -1581,7 +1581,10 @@ export default class Painter {
    *
    * @returns {Object} A result object container success/error status and log/toast messages.
    */
-  addOverlapMeasurements(overlapFrames) {
+  addOverlapMeasurements(
+    overlapFrames,
+    directions = ['top', 'bottom', 'right', 'left'],
+  ) {
     const result = {
       status: null,
       messages: {
@@ -1606,8 +1609,6 @@ export default class Painter {
       result.messages.alert = 'Could not find a overlapped layers in your selection';
       return result;
     }
-
-    const directions = ['top', 'bottom', 'right', 'left'];
 
     directions.forEach((direction) => {
       // do not annotate if the results are negative, or less than a single
@@ -1641,7 +1642,7 @@ export default class Painter {
 
     // return a successful result
     result.status = 'success';
-    result.messages.log = `Spacing annotated for “${this.layer.name()}”`;
+    result.messages.log = `Spacing (${directions.join(', ')}) annotated for “${this.layer.name()}”`;
     return result;
   }
 }

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -435,7 +435,6 @@ const positionAnnotation = (
   }
 
   // ------- position the group within the artboard, above the layer receiving the annotation
-  let horizontalAdjustment = null;
   let artboardEdge = null;
 
   // initial placement based on layer to annotate
@@ -475,20 +474,19 @@ const positionAnnotation = (
 
   // correct for left bleed
   if (placementX < 0) {
+    artboardEdge = 'left';
     placementX = 5;
-    horizontalAdjustment = 'left';
 
     // dimension/spacing annotations get their own special correction
     if (icon) {
-      placementX = 2;
       iconOffsetX = placementX;
     }
   }
 
   // correct for right bleed
   if ((placementX + group.frame.width) > artboardWidth) {
-    placementX = artboardWidth - group.frame.width - 5;
-    horizontalAdjustment = 'right';
+    artboardEdge = 'right';
+    placementX = artboardWidth - group.frame.width - 3;
 
     // dimension/spacing annotations get their own special correction
     if (icon) {
@@ -528,10 +526,10 @@ const positionAnnotation = (
   group.frame.y = placementY - relativeGroupFrame.y;
 
   // adjust diamond on horizonal placement, if necessary
-  if (horizontalAdjustment) {
+  if (artboardEdge) {
     // move the diamond to the mid-point of the layer to annotate
     let diamondLayerMidX = null;
-    switch (horizontalAdjustment) {
+    switch (artboardEdge) {
       case 'left':
         diamondLayerMidX = ((layerX - group.frame.x) + ((layerWidth - 6) / 2));
         break;
@@ -539,7 +537,7 @@ const positionAnnotation = (
         diamondLayerMidX = ((layerX - group.frame.x) + ((layerWidth - 6) / 2));
         break;
       default:
-        diamondLayerMidX = 0;
+        diamondLayerMidX = diamond.frame.x;
     }
     diamond.frame.x = diamondLayerMidX;
   }
@@ -566,16 +564,22 @@ const positionAnnotation = (
   }
 
   // adjust diamond based on artboard edge, if necessary
-  if (artboardEdge) {
+  if (artboardEdge && isMeasurement) {
     switch (artboardEdge) {
       case 'bottom':
         diamond.frame.y = rectangle.frame.height - diamond.frame.height - offsetY;
+        break;
+      case 'left':
+        diamond.frame.x = diamond.frame.width / 2;
+        break;
+      case 'right':
+        diamond.frame.x = rectangle.frame.width - diamond.frame.width - offsetX - 2;
         break;
       case 'top':
         diamond.frame.y = diamond.frame.height / 2;
         break;
       default:
-        return null;
+        diamond.frame.y = diamond.frame.y;
     }
   }
 
@@ -584,7 +588,7 @@ const positionAnnotation = (
     icon.frame.width = layerWidth;
 
     if (iconOffsetX > 0) {
-      if (horizontalAdjustment === 'left') {
+      if (artboardEdge === 'left') {
         icon.frame.x -= getPositionOnArtboard(icon.sketchObject).x;
       } else {
         icon.frame.x = (

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -1494,8 +1494,16 @@ export default class Painter {
     const types = ['top', 'bottom', 'right', 'left'];
 
     types.forEach((type) => {
+      // do not annotate if the results are negative, or less than a single
+      // IS-X spacing unit
+      if (overlapFrames[type].width <= 2 || overlapFrames[type].height <= 2) {
+        return null;
+      }
+
+      // otherwise, set up the frame we can use for the annotation
       let frameX = overlapFrames[type].x + (overlapFrames[type].width / 2);
       let frameY = overlapFrames[type].y;
+
       if ((type === 'left') || (type === 'right')) {
         frameY = overlapFrames[type].y + (overlapFrames[type].height / 2);
         frameX = overlapFrames[type].x;
@@ -1512,7 +1520,7 @@ export default class Painter {
         type,
       };
 
-      this.addSpacingAnnotation(spacingFrame);
+      return this.addSpacingAnnotation(spacingFrame);
     });
 
     // return a successful result

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -436,6 +436,7 @@ const positionAnnotation = (
 
   // ------- position the group within the artboard, above the layer receiving the annotation
   let horizontalAdjustment = null;
+  let artboardEdge = null;
 
   // initial placement based on layer to annotate
 
@@ -498,6 +499,7 @@ const positionAnnotation = (
 
   // correct for top bleed
   if (placementY < 0) {
+    artboardEdge = 'top';
     placementY = 5;
 
     // dimension/spacing annotations get their own special correction
@@ -509,6 +511,7 @@ const positionAnnotation = (
 
   // correct for bottom bleed
   if (placementY > (artboardHeight - group.frame.height)) {
+    artboardEdge = 'bottom';
     offsetY = icon ? 2 : 5;
     placementY = (artboardHeight - group.frame.height - offsetY);
 
@@ -560,6 +563,20 @@ const positionAnnotation = (
 
     // re-size the annotation group frame
     group.frame.y += 2;
+  }
+
+  // adjust diamond based on artboard edge, if necessary
+  if (artboardEdge) {
+    switch (artboardEdge) {
+      case 'bottom':
+        diamond.frame.y = rectangle.frame.height - diamond.frame.height - offsetY;
+        break;
+      case 'top':
+        diamond.frame.y = diamond.frame.height / 2;
+        break;
+      default:
+        return null;
+    }
   }
 
   // adjust the measure icon width for top-oriented annotations

--- a/src/Tools.js
+++ b/src/Tools.js
@@ -129,7 +129,17 @@ const getPositionOnArtboard = (layer) => {
     x: layer.frame().x(),
     y: layer.frame().y(),
   };
-  // look for an immediate parent
+
+  // check first if the layer is an artboard;
+  // artboards should simply return `x: 0, y: 0` by definition
+  // otherwise we get coordinates relative to the overall page
+  if (fromNative(layer).type === 'Artboard') {
+    coordinates.x = 0;
+    coordinates.y = 0;
+    return coordinates;
+  }
+
+  // otherwise, look for an immediate parent
   let { parent } = fromNative(layer);
 
   // loop through each parent and adjust the coordinates

--- a/src/constants.js
+++ b/src/constants.js
@@ -22,6 +22,13 @@ const PLUGIN_IDENTIFIER = 'com.linkedinlabs.sketch.auto-spec-plugin';
  */
 const PLUGIN_NAME = 'Specter';
 
+/**
+ * @description An object containing the set of colors in-use by the plugin.
+ *
+ * @kind constant
+ * @name COLORS
+ * @type {Object}
+ */
 const COLORS = {
   component: '#9966ff',
   custom: '#ff3399',

--- a/src/main.js
+++ b/src/main.js
@@ -209,6 +209,7 @@ const annotateMeasurement = (context = null) => {
       paintResult = painter.addGapMeasurement(gapFrame);
     } else {
       overlapFrames = crawler.overlapFrames();
+      paintResult = painter.addOverlapMeasurements(overlapFrames);
     }
 
     if (overlapFrames) {

--- a/src/main.js
+++ b/src/main.js
@@ -170,9 +170,12 @@ const annotateLayerCustom = (context = null) => {
   return null;
 };
 
-/** WIP
- * @description Annotates a selection of layers in a Sketch file with the
- * spacing number (“IS-X”) based on the gap between the two layers.
+/**
+ * @description If two layers are selected: annotates the selection with the
+ * spacing number (“IS-X”) based on either the gap between the two layers or, if they
+ * are overlapping, the 4 directions of overlap (top, bottom, right, and left). If
+ * one layer is selected: annotates the height and width of the selected layer
+ * in “dp” (digital points) units.
  *
  * @kind function
  * @name annotateMeasurement
@@ -223,13 +226,16 @@ const annotateMeasurement = (context = null) => {
   return null;
 };
 
-/** WIP
- * @description Annotates a selection of layers in a Sketch file with the
- * spacing number (“IS-X”) based on the gap between the two layers.
+/**
+ * @description Annotates the selection with the spacing number (“IS-X”) based on either
+ * the gap between the two layers or, if they are overlapping, the 4 directions of overlap
+ * (top, bottom, right, and left).
  *
  * @kind function
  * @name annotateSpacingOnly
  * @param {Object} context The current context (event) received from Sketch.
+ * @param {string} direction An optional string representing the annotation direction.
+ * Valid inputs are `top`, `bottom`, `right` (default), and `left`.
  * @returns {null} Shows a Toast in the UI if nothing is selected or
  * if more than two layers are selected.
  */
@@ -271,7 +277,7 @@ const annotateSpacingOnly = (context = null, direction = 'right') => {
 
   return null;
 };
-// export some `annotateSpacingOnly` aliases for the manifest to use in the plugin menu
+// export some pre-defined `annotateSpacingOnly` aliases for `manifest` to use in the plugin menu
 const annotateSpacingTop = (context = null) => annotateSpacingOnly(context, 'top');
 const annotateSpacingBottom = (context = null) => annotateSpacingOnly(context, 'bottom');
 const annotateSpacingLeft = (context = null) => annotateSpacingOnly(context, 'left');

--- a/src/main.js
+++ b/src/main.js
@@ -212,9 +212,7 @@ const annotateMeasurement = (context = null) => {
       paintResult = painter.addOverlapMeasurements(overlapFrames);
     }
 
-    if (overlapFrames) {
-      log('placeholder: paint padding dimensions here');
-    } else {
+    if (!overlapFrames && !gapFrame) {
       log('handle error here');
     }
   }

--- a/src/main.js
+++ b/src/main.js
@@ -199,11 +199,23 @@ const annotateMeasurement = (context = null) => {
   // set up Painter instance for the reference layer
   const painter = new Painter({ for: layer, in: document });
 
-  // draw the spacing annotation (if gap frame exists)
+  // draw the spacing annotation
+  // (if gap frame exists or layers are overlapped)
   let paintResult = null;
   if (selection.count() === 2) {
     const gapFrame = crawler.gapFrame();
-    paintResult = painter.addGapMeasurement(gapFrame);
+    let overlapFrames = null;
+    if (gapFrame) {
+      paintResult = painter.addGapMeasurement(gapFrame);
+    } else {
+      overlapFrames = crawler.overlapFrames();
+    }
+
+    if (overlapFrames) {
+      log('placeholder: paint padding dimensions here');
+    } else {
+      log('handle error here');
+    }
   }
 
   if (selection.count() === 1) {

--- a/src/main.js
+++ b/src/main.js
@@ -170,7 +170,7 @@ const annotateLayerCustom = (context = null) => {
   return null;
 };
 
-/**
+/** WIP
  * @description Annotates a selection of layers in a Sketch file with the
  * spacing number (“IS-X”) based on the gap between the two layers.
  *
@@ -211,10 +211,6 @@ const annotateMeasurement = (context = null) => {
       overlapFrames = crawler.overlapFrames();
       paintResult = painter.addOverlapMeasurements(overlapFrames);
     }
-
-    if (!overlapFrames && !gapFrame) {
-      log('handle error here');
-    }
   }
 
   if (selection.count() === 1) {
@@ -226,6 +222,60 @@ const annotateMeasurement = (context = null) => {
 
   return null;
 };
+
+/** WIP
+ * @description Annotates a selection of layers in a Sketch file with the
+ * spacing number (“IS-X”) based on the gap between the two layers.
+ *
+ * @kind function
+ * @name annotateSpacingOnly
+ * @param {Object} context The current context (event) received from Sketch.
+ * @returns {null} Shows a Toast in the UI if nothing is selected or
+ * if more than two layers are selected.
+ */
+const annotateSpacingOnly = (context = null, direction = 'right') => {
+  const {
+    document,
+    messenger,
+    selection,
+  } = assemble(context);
+
+  // need a selected layer to annotate it
+  if (selection === null || selection.count() !== 2) {
+    return messenger.alert('Two layers must be selected');
+  }
+
+  // grab the gap frame from the selection
+  const crawler = new Crawler({ for: selection });
+  const layer = crawler.first();
+
+  // set up Painter instance for the reference layer
+  const painter = new Painter({ for: layer, in: document });
+
+  // draw the spacing annotation
+  // (if gap frame exists or layers are overlapped)
+  let paintResult = null;
+  if (selection.count() === 2) {
+    const overlapFrames = crawler.overlapFrames();
+
+    if (overlapFrames) {
+      const directions = [direction];
+      paintResult = painter.addOverlapMeasurements(overlapFrames, directions);
+    } else {
+      return messenger.alert('The selected layers need to overlap');
+    }
+  }
+
+  // read the response from Painter; log and display message(s)
+  messenger.handleResult(paintResult);
+
+  return null;
+};
+// export some `annotateSpacingOnly` aliases for the manifest to use in the plugin menu
+const annotateSpacingTop = (context = null) => annotateSpacingOnly(context, 'top');
+const annotateSpacingBottom = (context = null) => annotateSpacingOnly(context, 'bottom');
+const annotateSpacingLeft = (context = null) => annotateSpacingOnly(context, 'left');
+const annotateSpacingRight = (context = null) => annotateSpacingOnly(context, 'right');
 
 /**
  * @description Draws a semi-transparent “Bounding Box” around any selected elements.
@@ -299,6 +349,10 @@ export {
   annotateLayer,
   annotateLayerCustom,
   annotateMeasurement,
+  annotateSpacingTop,
+  annotateSpacingBottom,
+  annotateSpacingLeft,
+  annotateSpacingRight,
   drawBoundingBox,
   onOpenDocument,
 };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Annotate and spec design system elements",
   "author": "LinkedIn",
   "homepage": "https://github.com/linkedinlabs/specter-sketch",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "appcast": "https://raw.githubusercontent.com/linkedinlabs/specter-sketch/master/.appcast.xml",
   "compatibleVersion": "55.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,8 +39,9 @@
       "handler": "drawBoundingBox"
     },
     {
-      "name": "Show Toolbar",
+      "name": "Show/Hide Toolbar",
       "identifier": "view-gui",
+      "shortcut": "ctrl shift p",
       "script": "./GUI.js",
       "handlers": {
         "run": "onRun",
@@ -65,8 +66,10 @@
     "items": [
       "annotate-layer",
       "annotate-layer-custom",
+      "-",
       "annotate-measurement",
       "draw-bounding-box",
+      "-",
       "view-gui"
     ]
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,7 +41,7 @@
     {
       "name": "Show/Hide Toolbar",
       "identifier": "view-gui",
-      "shortcut": "ctrl shift p",
+      "shortcut": "ctrl shift s",
       "script": "./GUI.js",
       "handlers": {
         "run": "onRun",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,11 +25,39 @@
       "handler": "annotateLayerCustom"
     },
     {
-      "name": "Set Measurement",
+      "name": "Set Spacing / Dimensions",
       "identifier": "annotate-measurement",
       "shortcut": "ctrl shift m",
       "script": "./main.js",
       "handler": "annotateMeasurement"
+    },
+    {
+      "name": "Set Spacing: Left",
+      "identifier": "annotate-spacing-left",
+      "shortcut": "ctrl shift option ←",
+      "script": "./main.js",
+      "handler": "annotateSpacingLeft"
+    },
+    {
+      "name": "Set Spacing: Right",
+      "identifier": "annotate-spacing-right",
+      "shortcut": "ctrl shift option →",
+      "script": "./main.js",
+      "handler": "annotateSpacingRight"
+    },
+    {
+      "name": "Set Spacing: Top",
+      "identifier": "annotate-spacing-top",
+      "shortcut": "ctrl shift option ↑",
+      "script": "./main.js",
+      "handler": "annotateSpacingTop"
+    },
+    {
+      "name": "Set Spacing: Bottom",
+      "identifier": "annotate-spacing-bottom",
+      "shortcut": "ctrl shift option ↓",
+      "script": "./main.js",
+      "handler": "annotateSpacingBottom"
     },
     {
       "name": "Draw Bounding Box",
@@ -69,6 +97,11 @@
       "-",
       "annotate-measurement",
       "draw-bounding-box",
+      "-",
+      "annotate-spacing-top",
+      "annotate-spacing-bottom",
+      "annotate-spacing-left",
+      "annotate-spacing-right",
       "-",
       "view-gui"
     ]


### PR DESCRIPTION
Updates the “Spacing” feature to work with overlapped layers (currently annotates the distance between two layers).

<img width="832" alt="Screen Shot 2019-09-06 at 4 41 58 PM" src="https://user-images.githubusercontent.com/867428/64466171-4702a080-d0c5-11e9-94c5-0acd3ab01cfc.png">
