### PR TITLE
Index Comparison Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-specter",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sketch-specter",
   "description": "A Sketch plugin for easily spec’ing design system elements.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/linkedinlabs/specter-sketch.git"

--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -1,5 +1,9 @@
 import { fromNative } from 'sketch';
-import { getPositionOnArtboard, setArray } from './Tools';
+import {
+  getPositionOnArtboard,
+  getRelativeIndex,
+  setArray,
+} from './Tools';
 
 /**
  * @description A class to handle traversing an array of selected items and return useful items
@@ -355,32 +359,6 @@ export default class Crawler {
    * for the two layers used to calculated the overlapped areas.
    */
   overlapFrames() {
-    /**
-     * @description Compensates for a mix of `Artboard` and non-artboard layers when
-     * determining a layer index. Artboard layer indexes are converted to a negative
-     * number so they can be compared against non-artboard layers. This is necessary
-     * because artboards use a separate z-index, making it possible for an artboard
-     * and a layer on that artboard to have the same index value.
-     *
-     * @kind function
-     * @name relativeIndex
-     * @param {Object} layer The sketchObject layer.
-     * @returns {number} The index.
-     * @private
-     */
-    const relativeIndex = (layer) => {
-      const layerType = fromNative(layer).type;
-      let layerIndex = fromNative(layer).index;
-
-      // artboards use their own z-index
-      // flip them to a negative for consistent comparison to items on artboards
-      if (layerType === 'Artboard') {
-        layerIndex = (0 - (layerIndex + 1));
-      }
-
-      return layerIndex;
-    };
-
     // use `gapFrame` to first ensure that the items do actually overlap
     const gapFrame = this.gapFrame();
 
@@ -400,13 +378,13 @@ export default class Crawler {
     let layerB = selection[selection.length - 1];
 
     // find bottom (`layerA`) and top (`layerB`) layers
-    let layerAIndex = relativeIndex(layerA);
-    let layerBIndex = relativeIndex(layerB);
+    let layerAIndex = getRelativeIndex(layerA);
+    let layerBIndex = getRelativeIndex(layerB);
 
     // set the bottom layer to `layerA` and the top to `layerB`
     // if `layerB` is currently the bottom, we have to flip them
     selection.forEach((layer) => {
-      const layerIndex = relativeIndex(layer);
+      const layerIndex = getRelativeIndex(layer);
 
       if (layerIndex > layerBIndex) {
         layerB = layer;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Annotate and spec design system elements",
   "author": "LinkedIn",
   "homepage": "https://github.com/linkedinlabs/specter-sketch",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "appcast": "https://raw.githubusercontent.com/linkedinlabs/specter-sketch/master/.appcast.xml",
   "compatibleVersion": "55.0",


### PR DESCRIPTION
Replaces the `relativeIndex` comparison method in `Crawler` with a more general `getRelativeIndex` in `Tools`. The new version takes Groups into account when generating an index.