### PR TITLE
Shared style fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-specter",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sketch-specter",
   "description": "A Sketch plugin for easily spec’ing design system elements.",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/linkedinlabs/specter-sketch.git"

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -297,17 +297,25 @@ export default class Identifier {
     // locate a shared style in Lingo
     if (sharedStyleId) {
       const kitStyle = lingoData.layerStyles[sharedStyleId] || lingoData.textStyles[sharedStyleId];
+      let textToSet = null;
 
       if (kitStyle) {
         // take only the last segment of the name (after a “/”, if available)
-        const textToSet = cleanName(kitStyle.name);
+        textToSet = cleanName(kitStyle.name);
+        result.messages.log = `Style Name in Lingo Kit for “${this.layer.name()}” is “${textToSet}”`;
+      }
 
+      if (!textToSet && layerJSON.sharedStyle && layerJSON.sharedStyle.name) {
+        textToSet = cleanName(layerJSON.sharedStyle.name);
+        result.messages.log = `Style Name in Shared Styles for “${this.layer.name()}” is “${textToSet}”`;
+      }
+
+      if (textToSet) {
         // set `annotationText` on the layer settings as the kit layer name
         setAnnotationTextSettings(textToSet, null, 'style', this.layer);
 
         // log the official name alongside the original layer name and set as success
         result.status = 'success';
-        result.messages.log = `Style Name in Lingo Kit for “${this.layer.name()}” is “${textToSet}”`;
         return result;
       }
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Annotate and spec design system elements",
   "author": "LinkedIn",
   "homepage": "https://github.com/linkedinlabs/specter-sketch",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "appcast": "https://raw.githubusercontent.com/linkedinlabs/specter-sketch/master/.appcast.xml",
   "compatibleVersion": "55.0",


### PR DESCRIPTION
If a style cannot be found in a linked Lingo Kit, fall back to the shared style name (if it exists) instead of skipping the annotation.