### PR TITLE
plugin menu - remove “/” characters + bump version to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-specter",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sketch-specter",
   "description": "A Sketch plugin for easily spec’ing design system elements.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/linkedinlabs/specter-sketch.git"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Annotate and spec design system elements",
   "author": "LinkedIn",
   "homepage": "https://github.com/linkedinlabs/specter-sketch",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "appcast": "https://raw.githubusercontent.com/linkedinlabs/specter-sketch/master/.appcast.xml",
   "compatibleVersion": "55.0",
@@ -25,7 +25,7 @@
       "handler": "annotateLayerCustom"
     },
     {
-      "name": "Set Spacing / Dimensions",
+      "name": "Set Spacing or Dimensions",
       "identifier": "annotate-measurement",
       "shortcut": "ctrl shift m",
       "script": "./main.js",
@@ -67,7 +67,7 @@
       "handler": "drawBoundingBox"
     },
     {
-      "name": "Show/Hide Toolbar",
+      "name": "Show or Hide Toolbar",
       "identifier": "view-gui",
       "shortcut": "ctrl shift s",
       "script": "./GUI.js",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,7 +25,7 @@
       "handler": "annotateLayerCustom"
     },
     {
-      "name": "Set Spacing or Dimensions",
+      "name": "Set Spacing / Dimensions",
       "identifier": "annotate-measurement",
       "shortcut": "ctrl shift m",
       "script": "./main.js",
@@ -67,7 +67,7 @@
       "handler": "drawBoundingBox"
     },
     {
-      "name": "Show or Hide Toolbar",
+      "name": "Show / Hide Toolbar",
       "identifier": "view-gui",
       "shortcut": "ctrl shift s",
       "script": "./GUI.js",


### PR DESCRIPTION
Seems related to certain menu items disappearing in `1.2.0`.